### PR TITLE
add navigation buttons in MultilingualAbstract when necessary

### DIFF
--- a/packages/react-tei/src/abstract/MultilingualAbstract.spec.tsx
+++ b/packages/react-tei/src/abstract/MultilingualAbstract.spec.tsx
@@ -55,6 +55,105 @@ const abstracts: DocumentJson[] = [
 	},
 ];
 
+const abstracts6Languages: DocumentJson[] = [
+	{
+		tag: "abstract",
+		attributes: { "@xml:lang": "en" },
+		value: [
+			{
+				tag: "p",
+				attributes: {},
+				value: [
+					{
+						tag: "#text",
+						value: "This is an abstract in English.",
+					},
+				],
+			},
+		],
+	},
+	{
+		tag: "abstract",
+		attributes: { "@xml:lang": "fr" },
+		value: [
+			{
+				tag: "p",
+				attributes: {},
+				value: [
+					{
+						tag: "#text",
+						value: "Ceci est un résumé en français.",
+					},
+				],
+			},
+		],
+	},
+	{
+		tag: "abstract",
+		attributes: { "@xml:lang": "de" },
+		value: [
+			{
+				tag: "p",
+				attributes: {},
+				value: [
+					{
+						tag: "#text",
+						value: "Dies ist eine Zusammenfassung auf Deutsch.",
+					},
+				],
+			},
+		],
+	},
+	{
+		tag: "abstract",
+		attributes: { "@xml:lang": "es" },
+		value: [
+			{
+				tag: "p",
+				attributes: {},
+				value: [
+					{
+						tag: "#text",
+						value: "Este es un resumen en español.",
+					},
+				],
+			},
+		],
+	},
+	{
+		tag: "abstract",
+		attributes: { "@xml:lang": "it" },
+		value: [
+			{
+				tag: "p",
+				attributes: {},
+				value: [
+					{
+						tag: "#text",
+						value: "Questo è un riassunto in italiano.",
+					},
+				],
+			},
+		],
+	},
+	{
+		tag: "abstract",
+		attributes: { "@xml:lang": "pt" },
+		value: [
+			{
+				tag: "p",
+				attributes: {},
+				value: [
+					{
+						tag: "#text",
+						value: "Este é um resumo em português.",
+					},
+				],
+			},
+		],
+	},
+];
+
 async function renderMultilingualAbstract() {
 	const screen = await render(<MultilingualAbstract abstracts={abstracts} />, {
 		wrapper: ({ children }) => (
@@ -162,5 +261,190 @@ describe("MultilingualAbstract", () => {
 		});
 
 		expect(section).not.toBeInTheDocument();
+	});
+
+	it("should render navigation buttons when more than 4 languages are present", async () => {
+		const screen = await render(
+			<MultilingualAbstract abstracts={abstracts6Languages} />,
+			{
+				wrapper: ({ children }) => (
+					<I18nProvider>
+						<TagCatalogProvider tagCatalog={tagCatalog}>
+							{children}
+						</TagCatalogProvider>
+					</I18nProvider>
+				),
+			},
+		);
+
+		const section = screen.getByRole("region", {
+			name: "Résumé",
+		});
+
+		expect(section).toBeVisible();
+
+		const heading = section.getByRole("heading", { level: 3, name: "Résumé" });
+		expect(heading).toBeVisible();
+
+		await heading.click();
+
+		const tablist = section.getByRole("tablist");
+		expect(tablist).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "anglais",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "français",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "allemand",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "espagnol",
+			}),
+		).toBeVisible();
+		// The following languages should not be visible initially
+		expect(
+			tablist.getByRole("tab", {
+				name: "italien",
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			tablist.getByRole("tab", {
+				name: "portugais",
+			}),
+		).not.toBeInTheDocument();
+
+		const previousButton = tablist.getByRole("button", {
+			name: "Langue précédente",
+		});
+		const nextButton = tablist.getByRole("button", {
+			name: "Langue suivante",
+		});
+
+		expect(previousButton).toBeVisible();
+		expect(previousButton).toBeDisabled();
+		expect(nextButton).toBeVisible();
+		expect(nextButton).not.toBeDisabled();
+
+		// Click next to navigate to the next set of languages
+		await nextButton.click();
+
+		expect(previousButton).not.toBeDisabled();
+
+		expect(
+			tablist.getByRole("tab", {
+				name: "anglais",
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			tablist.getByRole("tab", {
+				name: "français",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "allemand",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "espagnol",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "italien",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "portugais",
+			}),
+		).not.toBeInTheDocument();
+
+		await tablist
+			.getByRole("button", {
+				name: "Langue précédente",
+			})
+			.click();
+
+		expect(
+			tablist.getByRole("tab", {
+				name: "anglais",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "français",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "allemand",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "espagnol",
+			}),
+		).toBeVisible();
+		expect(
+			tablist.getByRole("tab", {
+				name: "italien",
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			tablist.getByRole("tab", {
+				name: "portugais",
+			}),
+		).not.toBeInTheDocument();
+	});
+
+	it("should not render navigation buttons when 4 or fewer languages are present", async () => {
+		const screen = await render(
+			<MultilingualAbstract abstracts={abstracts} />,
+			{
+				wrapper: ({ children }) => (
+					<I18nProvider>
+						<TagCatalogProvider tagCatalog={tagCatalog}>
+							{children}
+						</TagCatalogProvider>
+					</I18nProvider>
+				),
+			},
+		);
+
+		const section = screen.getByRole("region", {
+			name: "Résumé",
+		});
+
+		expect(section).toBeVisible();
+
+		const heading = section.getByRole("heading", { level: 3, name: "Résumé" });
+		expect(heading).toBeVisible();
+
+		await heading.click();
+
+		const tablist = section.getByRole("tablist");
+		expect(tablist).toBeVisible();
+
+		expect(
+			tablist.getByRole("button", {
+				name: "Langue précédente",
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			tablist.getByRole("button", {
+				name: "Langue suivante",
+			}),
+		).not.toBeInTheDocument();
 	});
 });

--- a/packages/react-tei/src/abstract/MultilingualAbstract.tsx
+++ b/packages/react-tei/src/abstract/MultilingualAbstract.tsx
@@ -1,10 +1,13 @@
+import { ChevronLeft, ChevronRight } from "@mui/icons-material";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { DocumentJson, DocumentJsonValue } from "../parser/document";
 import { Value } from "../tags/Value";
 import { AbstractAccordion } from "./AbstractAccordion";
+
+const MAX_VISIBLE_TABS = 4;
 
 export function MultilingualAbstract({ abstracts }: MultilingualAbstractProps) {
 	const { t, i18n } = useTranslation();
@@ -31,16 +34,46 @@ export function MultilingualAbstract({ abstracts }: MultilingualAbstractProps) {
 	const [selectedLang, setSelectedLang] = useState<string>(
 		tabs?.at(0)?.lang ?? "",
 	);
+	const [startIndex, setStartIndex] = useState<number>(0);
+
+	const visibleTabs = useMemo(
+		() => tabs.slice(startIndex, startIndex + MAX_VISIBLE_TABS),
+		[startIndex, tabs],
+	);
+	const canGoPrevious = startIndex > 0;
+	const canGoNext = startIndex + MAX_VISIBLE_TABS < tabs.length;
+
+	const handlePrevious = () => {
+		if (canGoPrevious) {
+			setStartIndex((prev) => prev - 1);
+		}
+	};
+
+	const handleNext = () => {
+		if (canGoNext) {
+			setStartIndex((prev) => prev + 1);
+		}
+	};
 
 	if (!tabs.length) {
 		console.warn("No valid abstracts to display.", abstracts);
 		return null;
 	}
-
 	return (
-		<AbstractAccordion title={t("document.abstract")}>
+		<AbstractAccordion title={t("document.abstract.title")}>
 			<ButtonGroup role="tablist" aria-label={t("document.lang")}>
-				{tabs.map((tab, index) => {
+				{tabs.length > 4 && (
+					<Button
+						onClick={handlePrevious}
+						disabled={!canGoPrevious}
+						variant="outlined"
+						title={t("document.abstract.previousLanguage")}
+						aria-label={t("document.abstract.previousLanguage")}
+					>
+						<ChevronLeft />
+					</Button>
+				)}
+				{visibleTabs.map((tab) => {
 					const label = Intl.DisplayNames
 						? new Intl.DisplayNames([i18n.language], {
 								type: "language",
@@ -51,7 +84,6 @@ export function MultilingualAbstract({ abstracts }: MultilingualAbstractProps) {
 						<Button
 							key={tab.lang}
 							role="tab"
-							tabIndex={index}
 							aria-selected={selectedLang === tab.lang}
 							onClick={() => setSelectedLang(tab.lang)}
 							variant={selectedLang === tab.lang ? "contained" : "outlined"}
@@ -60,6 +92,17 @@ export function MultilingualAbstract({ abstracts }: MultilingualAbstractProps) {
 						</Button>
 					);
 				})}
+				{tabs.length > 4 && (
+					<Button
+						onClick={handleNext}
+						disabled={!canGoNext}
+						variant="outlined"
+						title={t("document.abstract.nextLanguage")}
+						aria-label={t("document.abstract.nextLanguage")}
+					>
+						<ChevronRight />
+					</Button>
+				)}
 			</ButtonGroup>
 
 			{tabs.map((tab) => {

--- a/packages/react-tei/src/abstract/SingleAbstract.tsx
+++ b/packages/react-tei/src/abstract/SingleAbstract.tsx
@@ -33,7 +33,7 @@ export function SingleAbstract({ abstract }: SingleAbstractProps) {
 
 	return (
 		<AbstractAccordion
-			title={head ? <Value data={head?.value} /> : t("document.abstract")}
+			title={head ? <Value data={head?.value} /> : t("document.abstract.title")}
 		>
 			<Value data={content} />
 		</AbstractAccordion>

--- a/packages/react-tei/src/i18n/I18NProvider.spec.tsx
+++ b/packages/react-tei/src/i18n/I18NProvider.spec.tsx
@@ -7,11 +7,11 @@ import { I18nProvider } from "./I18nProvider";
 function TestFunction() {
 	const { t } = useTranslation();
 
-	return t("document.abstract");
+	return t("document.abstract.title");
 }
 
 describe("I18NProvider", () => {
-	it("should translate document.abstract", async () => {
+	it("should translate document.abstract.title", async () => {
 		const screen = await render(
 			<I18nProvider>
 				<TestFunction />

--- a/packages/react-tei/src/i18n/locales/en.ts
+++ b/packages/react-tei/src/i18n/locales/en.ts
@@ -2,7 +2,11 @@ import type { Translation } from "./fr";
 
 export const en: Translation = {
 	document: {
-		abstract: "Abstract",
+		abstract: {
+			title: "Abstract",
+			nextLanguage: "Next Language",
+			previousLanguage: "Previous Language",
+		},
 		tableOfContent: "Table of Contents",
 		lang: "Language",
 	},

--- a/packages/react-tei/src/i18n/locales/fr.ts
+++ b/packages/react-tei/src/i18n/locales/fr.ts
@@ -1,6 +1,10 @@
 export const fr = {
 	document: {
-		abstract: "Résumé",
+		abstract: {
+			title: "Résumé",
+			nextLanguage: "Langue suivante",
+			previousLanguage: "Langue précédente",
+		},
 		tableOfContent: "Table des matières",
 		lang: "Langue",
 	},


### PR DESCRIPTION
closes #10 

I added navigation button to allow to see more than 4 buttons.

<img width="603" height="174" alt="image" src="https://github.com/user-attachments/assets/c54a3a2f-055b-4b4f-9a55-5e3abe8d01cc" />


Adding a dropdown button did not work well. When there is on 5 language, we get a drop down button with only one option.
And when selecting an option it is not clear anymore there are others.
