### PR TITLE
Fix(abstract): Always show translated key for single abstract instead of head

### DIFF
--- a/packages/e2e/testdata/toc.tei
+++ b/packages/e2e/testdata/toc.tei
@@ -124,7 +124,21 @@
 
                     <div type="2.1" xml:id="s0002">
                         <head>Part 1.1</head>
-                        <p> Integer <hi rend="bold">faucibus eros</hi> eget eleifend convallis. </p>
+                        <p>
+                            In sollicitudin efficitur placerat. Praesent a velit quis magna finibus tristique. Pellentesque ligula leo, euismod quis risus ornare, maximus imperdiet mi. Fusce eget lobortis nunc. In gravida ante nec quam varius, eget molestie lorem scelerisque. Sed porta neque sed ultrices imperdiet. Donec malesuada urna eu magna congue, in lacinia dui pulvinar. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Duis quis posuere ex.
+                        </p>
+
+                        <p>
+                            Fusce odio augue, ultricies nec tempor non, malesuada iaculis sem. Ut eget augue placerat, lobortis tortor scelerisque, tincidunt orci. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Praesent interdum justo nec elit varius, in interdum augue faucibus. Donec bibendum lectus non mi posuere, eget mattis lectus vestibulum. Donec urna lorem, porttitor ut volutpat vel, pellentesque vel lacus. Praesent in cursus nunc, vitae pulvinar nunc. Maecenas tempus purus auctor convallis aliquam. Quisque nisi augue, egestas eu nisi id, commodo egestas lacus. Pellentesque nec nunc malesuada, pretium dui in, vehicula purus. Morbi sed odio a lectus accumsan euismod. Duis et libero quis erat vulputate rutrum eget vitae sem. Sed pulvinar ultrices lacus, quis finibus massa condimentum at. Maecenas pulvinar eu felis quis vehicula.
+                        </p>
+
+                        <p>
+                            Fusce odio augue, ultricies nec tempor non, malesuada iaculis sem. Ut eget augue placerat, lobortis tortor scelerisque, tincidunt orci. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Praesent interdum justo nec elit varius, in interdum augue faucibus. Donec bibendum lectus non mi posuere, eget mattis lectus vestibulum. Donec urna lorem, porttitor ut volutpat vel, pellentesque vel lacus. Praesent in cursus nunc, vitae pulvinar nunc. Maecenas tempus purus auctor convallis aliquam. Quisque nisi augue, egestas eu nisi id, commodo egestas lacus. Pellentesque nec nunc malesuada, pretium dui in, vehicula purus. Morbi sed odio a lectus accumsan euismod. Duis et libero quis erat vulputate rutrum eget vitae sem. Sed pulvinar ultrices lacus, quis finibus massa condimentum at. Maecenas pulvinar eu felis quis vehicula.
+                        </p>
+
+                        <p>
+                            Fusce odio augue, ultricies nec tempor non, malesuada iaculis sem. Ut eget augue placerat, lobortis tortor scelerisque, tincidunt orci. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Praesent interdum justo nec elit varius, in interdum augue faucibus. Donec bibendum lectus non mi posuere, eget mattis lectus vestibulum. Donec urna lorem, porttitor ut volutpat vel, pellentesque vel lacus. Praesent in cursus nunc, vitae pulvinar nunc. Maecenas tempus purus auctor convallis aliquam. Quisque nisi augue, egestas eu nisi id, commodo egestas lacus. Pellentesque nec nunc malesuada, pretium dui in, vehicula purus. Morbi sed odio a lectus accumsan euismod. Duis et libero quis erat vulputate rutrum eget vitae sem. Sed pulvinar ultrices lacus, quis finibus massa condimentum at. Maecenas pulvinar eu felis quis vehicula.
+                        </p>
                     </div>
                 </div>
 

--- a/packages/react-tei/src/DocumentAbstract.spec.tsx
+++ b/packages/react-tei/src/DocumentAbstract.spec.tsx
@@ -115,14 +115,14 @@ describe("DocumentAbstract", () => {
 		});
 
 		const section = screen.getByRole("region", {
-			name: "Abstract",
+			name: "Résumé",
 		});
 
 		await expect.element(section).toBeVisible();
 
 		const heading = section.getByRole("heading", {
 			level: 3,
-			name: "Abstract",
+			name: "Résumé",
 		});
 		await expect.element(heading).toBeVisible();
 

--- a/packages/react-tei/src/abstract/SingleAbstract.spec.tsx
+++ b/packages/react-tei/src/abstract/SingleAbstract.spec.tsx
@@ -46,14 +46,14 @@ describe("SingleAbstract", () => {
 		});
 
 		const section = screen.getByRole("region", {
-			name: "Sample Abstract Title",
+			name: "Résumé",
 		});
 
 		expect(section).toBeVisible();
 
 		const heading = section.getByRole("heading", {
 			level: 3,
-			name: "Sample Abstract Title",
+			name: "Résumé",
 		});
 		expect(heading).toBeVisible();
 
@@ -121,14 +121,14 @@ describe("SingleAbstract", () => {
 		});
 
 		const section = screen.getByRole("region", {
-			name: "Sample Abstract Title",
+			name: "Résumé",
 		});
 
 		expect(section).toBeVisible();
 
 		const heading = section.getByRole("heading", {
 			level: 3,
-			name: "Sample Abstract Title",
+			name: "Résumé",
 		});
 		expect(heading).toBeVisible();
 
@@ -139,54 +139,6 @@ describe("SingleAbstract", () => {
 		expect(
 			section.getByRole("paragraph").filter({
 				hasText: "This is a sample abstract with a highlighted word.",
-			}),
-		).toBeVisible();
-	});
-
-	it("should support abstracts without head", async () => {
-		const abstractJson: DocumentJson = {
-			tag: "abstract",
-			attributes: {},
-			value: [
-				{
-					tag: "p",
-					attributes: {},
-					value: [
-						{
-							tag: "#text",
-							value: "This abstract has no head element.",
-						},
-					],
-				},
-			],
-		};
-
-		const screen = await render(<SingleAbstract abstract={abstractJson} />, {
-			wrapper: ({ children }) => (
-				<I18nProvider>
-					<TagCatalogProvider tagCatalog={tagCatalog}>
-						{children}
-					</TagCatalogProvider>
-				</I18nProvider>
-			),
-		});
-
-		const section = screen.getByRole("region", {
-			name: "Résumé",
-		});
-
-		expect(section).toBeVisible();
-
-		const heading = section.getByRole("heading", { level: 3, name: "Résumé" });
-		expect(heading).toBeVisible();
-
-		expect(section.getByRole("paragraph")).not.toBeInTheDocument();
-
-		await heading.click();
-
-		expect(
-			section.getByRole("paragraph").filter({
-				hasText: "This abstract has no head element.",
 			}),
 		).toBeVisible();
 	});

--- a/packages/react-tei/src/abstract/SingleAbstract.tsx
+++ b/packages/react-tei/src/abstract/SingleAbstract.tsx
@@ -13,14 +13,6 @@ export function SingleAbstract({ abstract }: SingleAbstractProps) {
 		[abstract],
 	);
 
-	const head = useMemo(
-		() =>
-			Array.isArray(transformedAbstract.value)
-				? transformedAbstract.value.find((item) => item.tag === "head")
-				: undefined,
-		[transformedAbstract],
-	);
-
 	const content = useMemo(
 		() =>
 			Array.isArray(transformedAbstract.value)
@@ -32,9 +24,7 @@ export function SingleAbstract({ abstract }: SingleAbstractProps) {
 	);
 
 	return (
-		<AbstractAccordion
-			title={head ? <Value data={head?.value} /> : t("document.abstract.title")}
-		>
+		<AbstractAccordion title={t("document.abstract.title")}>
 			<Value data={content} />
 		</AbstractAccordion>
 	);


### PR DESCRIPTION
Closes #115 

This PR also fixes a flaky TOC E2E test

## Additional Checks

- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The **documentation** is up to date
