### PR TITLE
pass unitext term to attributes

### DIFF
--- a/packages/react-tei/src/unitex/enrichDocumentWithUnitex.ts
+++ b/packages/react-tei/src/unitex/enrichDocumentWithUnitex.ts
@@ -69,6 +69,7 @@ export const enrichDocumentWithUnitex = (
 	const sortedTerms = [...terms].sort((a, b) => b.term.length - a.term.length);
 	const termRegexes = sortedTerms.map(({ term, groups, subTerms }) => ({
 		termRegex: termToRegex(term),
+		term,
 		groups,
 		value: subTerms?.length ? subTerms.map(termToTag) : term,
 	}));


### PR DESCRIPTION
Quick fix: preserve unitex term in highlight attribute.
We passed the matched text insteadwhich was preventing to link with the original term.
