### PR TITLE
add min width to image

### DIFF
--- a/packages/react-tei/src/tags/Figure.tsx
+++ b/packages/react-tei/src/tags/Figure.tsx
@@ -52,7 +52,8 @@ export function Figure({ data }: ComponentProps) {
 				<CardMedia
 					sx={{
 						background: (theme) => theme.palette.grey[100],
-						minHeight: 200,
+						minHeight: 240,
+						minWidth: 320,
 						display: "flex",
 						alignItems: "center",
 						justifyContent: "center",
@@ -70,7 +71,8 @@ export function Figure({ data }: ComponentProps) {
 				<CardMedia
 					sx={{
 						background: (theme) => theme.palette.grey[100],
-						minHeight: 200,
+						minHeight: 240,
+						minWidth: 320,
 						display: "flex",
 						alignItems: "center",
 						justifyContent: "center",


### PR DESCRIPTION
Closes #38
Closes #121

for better rendering inside table:

<img width="1502" height="751" alt="image" src="https://github.com/user-attachments/assets/532191a8-6312-4d3f-a1c1-7aa762b5ab43" />

outside table:

<img width="1852" height="928" alt="image" src="https://github.com/user-attachments/assets/0bb8dabf-7f8a-485f-8820-a1e296d270c1" />

