### PR TITLE
nest term of the same group

### DIFF
--- a/packages/react-tei/src/termEnrichment/computeEnrichedTerms.spec.ts
+++ b/packages/react-tei/src/termEnrichment/computeEnrichedTerms.spec.ts
@@ -260,7 +260,7 @@ describe("computeEnrichedTerms", () => {
 		]);
 	});
 
-	it("should not nest terms that are in the same group", () => {
+	it("should nest terms that are in the same group", () => {
 		const termByGroup = {
 			group1: [
 				{ term: "cat lover", displayed: true },
@@ -271,7 +271,22 @@ describe("computeEnrichedTerms", () => {
 		const terms = computeEnrichedTerms(termByGroup);
 
 		expect(terms).toEqual([
-			{ term: "cat lover", groups: ["group1"] },
+			{
+				term: "cat lover",
+				groups: ["group1"],
+				subTerms: [
+					{
+						groups: ["group1"],
+						term: "cat",
+					},
+					{
+						artificial: true,
+						groups: ["group1"],
+						sourceTerm: "cat lover",
+						term: " lover",
+					},
+				],
+			},
 			{ term: "cat", groups: ["group1"] },
 		]);
 	});

--- a/packages/react-tei/src/termEnrichment/nestContainedTerms.spec.ts
+++ b/packages/react-tei/src/termEnrichment/nestContainedTerms.spec.ts
@@ -39,18 +39,6 @@ describe("nestContainedTerms", () => {
 			expect(isContainedIn(longerTerm, shorterTerm)).toBe(true);
 		});
 
-		it("should return false when longerTerm contain shorter one but they are of the same group", () => {
-			const longerTerm = {
-				term: "cat lover",
-				groups: ["group1"],
-			};
-			const shorterTerm = {
-				term: "cat",
-				groups: ["group1"],
-			};
-			expect(isContainedIn(longerTerm, shorterTerm)).toBe(false);
-		});
-
 		it('should return false when longerTerm contain shorter one but shorter is not a full word (e.g., "conf" in "overconfident")', () => {
 			const longerTerm = {
 				term: "overconfident",

--- a/packages/react-tei/src/termEnrichment/nestContainedTerms.ts
+++ b/packages/react-tei/src/termEnrichment/nestContainedTerms.ts
@@ -7,9 +7,6 @@ export const isContainedIn = (
 	longer: GroupedTerm,
 	shorter: GroupedTerm,
 ): boolean => {
-	if (shorter.groups.every((g) => longer.groups.includes(g))) {
-		return false;
-	}
 	if (shorter.term === longer.term) return false;
 
 	const shorterWordRegex = new RegExp(


### PR DESCRIPTION
## Problem

Term of the same group are never nested, this prevent from displaying the nested group when the parent group gets hidden 

## Solution

Nest term of the same group too

## How To Test

Test on a document lile https://search.istex.fr/fr-FR/results?q=De+la+science+normale+%C3%A0+la+science+marginale.+Analyse+d%27une+bifurcation+de+trajectoire+scientifique%3A+le+cas+de+la+Th%C3%A9orie+de+la+Relativit%C3%A9+d%27Echelle with teeft enrichment.
The terms `lentilles gravitationnelles`, `lentilles` and `gravitationnelles` are all navigable and when hidding `lentilles gravitationnelles`, `lentilles` and `gravitationlles` are still underlined.

## Additional Checks

- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The **documentation** is up to date
