### PR TITLE
Improve formula style

### DIFF
--- a/packages/react-tei/src/tags/formula/FormulaRend.tsx
+++ b/packages/react-tei/src/tags/formula/FormulaRend.tsx
@@ -50,13 +50,29 @@ export function FormulaRend({ data }: ComponentProps) {
 	switch (rend) {
 		case "display":
 			return (
-				<Typography component="div" role="figure">
+				<Typography
+					component="div"
+					role="figure"
+					sx={{
+						"& math": {
+							display: "math block !important",
+						},
+					}}
+				>
 					<Value data={value} />
 				</Typography>
 			);
 		case "inline":
 			return (
-				<Typography component="span" role="figure">
+				<Typography
+					component="span"
+					role="figure"
+					sx={{
+						"& math": {
+							display: "math !important",
+						},
+					}}
+				>
 					<Value data={value} />
 				</Typography>
 			);


### PR DESCRIPTION
force math tag style to always be centered when rend=display and inline when rend=inline
